### PR TITLE
URA-262 eggd_sompt v1.0.2 - handle epic control sample name

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -2,8 +2,8 @@
   "name": "eggd_sompy",
   "title": "eggd_sompy",
   "summary": "Somatic Variant Benchmarking Tool",
-  "dxapi": "1.0.1",
-  "version": "1.0.1",
+  "dxapi": "1.0.2",
+  "version": "1.0.2",
   "authorizedUsers": [
     "org-emee_1"
   ],
@@ -15,7 +15,7 @@
       "name": "query_vcf_string",
       "class": "string",
       "optional": true,
-      "help": "The query sample name to run sompy on. If not provided, no outputs are generated"
+      "help": "The query sample name to run sompy on, can be in regex match format e.g Oncospan|-[0-9]+Q[0-9]+- . If not provided, no outputs are generated"
     },
     {
       "name": "truth_vcf",

--- a/src/eggd_sompy.sh
+++ b/src/eggd_sompy.sh
@@ -9,7 +9,7 @@ main() {
         echo "Query VCF and query VCF filename inputs are inputted"
 
         # check the query VCF and query VCF string filename match
-        if [[ "${query_vcf_name}" =~ "${query_vcf_string%%-*}"|-[0-9]+Q[0-9]+- ]]; then
+        if [[ "${query_vcf_name}" =~ "${query_vcf_string}" ]]; then
             echo "Query VCF and query VCF filename inputs are the same"
             # when there IS a query vcf
             # Download inputs from DNAnexus in parallel, these will be downloaded to /home/dnanexus/in/

--- a/src/eggd_sompy.sh
+++ b/src/eggd_sompy.sh
@@ -9,7 +9,7 @@ main() {
         echo "Query VCF and query VCF filename inputs are inputted"
 
         # check the query VCF and query VCF string filename match
-        if [[ "${query_vcf_name}" =~ "${query_vcf_string}" ]]; then
+        if [[ "${query_vcf_name}" =~ $query_vcf_string ]]; then
             echo "Query VCF and query VCF filename inputs are the same"
             # when there IS a query vcf
             # Download inputs from DNAnexus in parallel, these will be downloaded to /home/dnanexus/in/

--- a/src/eggd_sompy.sh
+++ b/src/eggd_sompy.sh
@@ -9,7 +9,7 @@ main() {
         echo "Query VCF and query VCF filename inputs are inputted"
 
         # check the query VCF and query VCF string filename match
-        if [ "${query_vcf_name%%-*}" == "${query_vcf_string%%-*}" ]; then
+        if [[ "${query_vcf_name}" =~ "${query_vcf_string%%-*}"|-[0-9]+Q[0-9]+- ]]; then
             echo "Query VCF and query VCF filename inputs are the same"
             # when there IS a query vcf
             # Download inputs from DNAnexus in parallel, these will be downloaded to /home/dnanexus/in/


### PR DESCRIPTION
Old oncospan control samplename : Oncospan-1157-1-AA1-BBB-MYE-U-EGG2
- Job: https://platform.dnanexus.com/projects/GV39zzj4X3KX73qZ2g6Xb4z4/monitor/job/GV3kz9j4X3Kbk2k1vFy4yF4X

New oncospan control samplename : 100033000-23061Q0007-23MYE1-8472
- Job: https://platform.dnanexus.com/projects/GV39zzj4X3KX73qZ2g6Xb4z4/monitor/job/GV3kfj84X3KY9BX8zV4vQp3G

App looks to see whether it starts with "Oncospan" or if there is a "Q" present which indicates a control samples. The app is able to handle both naming conventions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_sompy/5)
<!-- Reviewable:end -->
