### PR TITLE
fix issue with --keep_sum AD; fix issue with VCFs that have no contig info in header

### DIFF
--- a/src/eggd_sompy.sh
+++ b/src/eggd_sompy.sh
@@ -32,6 +32,8 @@ main() {
             prefix=$(basename $(basename ${query_vcf%%_*}))
 
             # normalise query VCF
+            ## indexing fixes an issue seen with some inputs: "Contig '1' is not defined in the header. (Quick workaround: index the file with tabix.)"
+            tabix $query_vcf
             query_vcf_name=$(sed -E 's/\.vcf(\.gz)?//g' <<< $(basename $query_vcf))
             normalised_query_vcf="${query_vcf_name}.normalized.vcf.gz"
             bcftools norm \
@@ -39,11 +41,12 @@ main() {
                 -W=tbi \
                 -f ${reference_file} \
                 -m -any \
-                --keep-sum AD \
                 -o "${normalised_query_vcf}" \
                 "${query_vcf}"
 
             # normalise truth VCF
+            ## indexing to fix bcftools not finding contig refs in header for some VCFs
+            tabix $truth_vcf
             truth_vcf_name=$(sed -E 's/\.vcf(\.gz)?//g' <<< $(basename $truth_vcf))
             normalised_truth_vcf="${truth_vcf_name}.normalized.vcf.gz"
             bcftools norm \
@@ -51,7 +54,6 @@ main() {
                 -W=tbi \
                 -f ${reference_file} \
                 -m -any \
-                --keep-sum AD \
                 -o "${normalised_truth_vcf}" \
                 "${truth_vcf}"
 


### PR DESCRIPTION
Fixes #10 & #11

Changes:

- `--keep_sum AD` removed from `bcftools norm` calls
- `tabix <file.vcf.gz>` step added before query and truth VCF processing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_sompy/12)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and error handling by ensuring both query and truth VCF files are indexed before normalisation, preventing header-related errors.
  * Removed the `--keep-sum AD` option during VCF normalisation for smoother processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->